### PR TITLE
parse of internet.user_name is not found

### DIFF
--- a/lib/charlatan/internet.js
+++ b/lib/charlatan/internet.js
@@ -71,11 +71,14 @@ exports.safeEmail = function (name) {
 exports.userName = function (name) {
   var glue = Helpers.sample('.', '_');
 
-  if (!!name) {
-    return fix_umlauts(name.splite(' ').join(glue));
+  if (!!!name) {
+    name = Charlatan.parse('name.name');
   }
 
-  return fix_umlauts(Charlatan.parse('internet.user_name'));
+  return fix_umlauts(name)
+          .replace(/[^\w\s]+/g, '')
+          .split(' ')
+          .join(glue);
 };
 
 


### PR DESCRIPTION
here's an idea to instead of use locale for usernames, just piggiback on the name generation.
