### PR TITLE
add name parameter to email generator

### DIFF
--- a/lib/charlatan/internet.js
+++ b/lib/charlatan/internet.js
@@ -32,8 +32,8 @@ function fix_umlauts(string) {
  * Generate email :-)
  *
  ***/
-exports.email = function () {
-  return this.userName().toLowerCase() + "@" + this.domainName();
+exports.email = function (name) {
+  return this.userName(name).toLowerCase() + "@" + this.domainName();
 };
 
 


### PR DESCRIPTION
the email generator does not have the name parameter defined, but safeEmail and freeEmail do. I think it should have it as well.
