### PR TITLE
Fix for en-gb postcode format

### DIFF
--- a/lib/locales/en-gb.yml
+++ b/lib/locales/en-gb.yml
@@ -1,7 +1,7 @@
 en-gb:
   faker:
     address:
-      postcode: /[A-PR-UWYZ0-9][A-HK-Y0-9][AEHMNPRTVXY0-9]?[ABEHMNPRVWXY0-9]? {1,2}[0-9][ABD-HJLN-UW-Z]{2}/
+      postcode: ['??## #??', '??# #??']
       county: [Avon, Bedfordshire, Berkshire, Borders, Buckinghamshire, Cambridgeshire, Central, Cheshire, Cleveland, Clwyd, Cornwall, County Antrim, County Armagh, County Down, County Fermanagh, County Londonderry, County Tyrone, Cumbria, Derbyshire, Devon, Dorset, Dumfries and Galloway, Durham, Dyfed, East Sussex, Essex, Fife, Gloucestershire, Grampian, Greater Manchester, Gwent, Gwynedd County, Hampshire, Herefordshire, Hertfordshire, Highlands and Islands, Humberside, Isle of Wight, Kent, Lancashire, Leicestershire, Lincolnshire, Lothian, Merseyside, Mid Glamorgan, Norfolk, North Yorkshire, Northamptonshire, Northumberland, Nottinghamshire, Oxfordshire, Powys, Rutland, Shropshire, Somerset, South Glamorgan, South Yorkshire, Staffordshire, Strathclyde, Suffolk, Surrey, Tayside, Tyne and Wear, Warwickshire, West Glamorgan, West Midlands, West Sussex, West Yorkshire, Wiltshire, Worcestershire]
       uk_country: [England, Scotland, Wales, Northern Ireland]
       default_country: [England, Scotland, Wales, Northern Ireland]


### PR DESCRIPTION
Charlatan.Address.postcode uses letterify and numerify internally and the current en-gb postcode format is defined as a regular expression. When using the en-gb locale, Charlatan returns postcodes following the en locale.

This fix is not perfect, due to the complexities of the UK postcode format, but is close enough from a random data point of view.
