### PR TITLE
Added street_suffix suitable for UK

### DIFF
--- a/lib/locales/en-gb.yml
+++ b/lib/locales/en-gb.yml
@@ -1,6 +1,7 @@
 en-gb:
   faker:
     address:
+      street_suffix: [Street, Road, Way, Avenue, Drive, Grove, Lane, Gardens, Place, Crescent, Close, Square, Hill, Mews, Vale, Dene, Rise, Mead, Court, Yard]
       postcode: ['??## #??', '??# #??']
       county: [Avon, Bedfordshire, Berkshire, Borders, Buckinghamshire, Cambridgeshire, Central, Cheshire, Cleveland, Clwyd, Cornwall, County Antrim, County Armagh, County Down, County Fermanagh, County Londonderry, County Tyrone, Cumbria, Derbyshire, Devon, Dorset, Dumfries and Galloway, Durham, Dyfed, East Sussex, Essex, Fife, Gloucestershire, Grampian, Greater Manchester, Gwent, Gwynedd County, Hampshire, Herefordshire, Hertfordshire, Highlands and Islands, Humberside, Isle of Wight, Kent, Lancashire, Leicestershire, Lincolnshire, Lothian, Merseyside, Mid Glamorgan, Norfolk, North Yorkshire, Northamptonshire, Northumberland, Nottinghamshire, Oxfordshire, Powys, Rutland, Shropshire, Somerset, South Glamorgan, South Yorkshire, Staffordshire, Strathclyde, Suffolk, Surrey, Tayside, Tyne and Wear, Warwickshire, West Glamorgan, West Midlands, West Sussex, West Yorkshire, Wiltshire, Worcestershire]
       uk_country: [England, Scotland, Wales, Northern Ireland]


### PR DESCRIPTION
Added UK street name suffixes, information taken from http://www.west-norfolk.gov.uk/default.aspx?page=23697
